### PR TITLE
update to dropbox 8.4.0

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,12 +4,12 @@
 	version="1.2"
 	provider-name="schapplm">
 	<requires>
-		<import addon="xbmc.python" version="2.20.0"/>
+		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.simplejson" version="2.0.10" />
 		<import addon="script.module.buggalo" version="1.1.3" /> <!-- min. version 1.1.3 for email report -->
 		<import addon="script.module.myconnpy" version="1.1.7" /> <!-- mySQL Connector for python. Default in XBMC since Frodo -->
 		<!--<import addon="script.module.pydevd" version="3.4.1"/> --> <!-- Required for remote debugging in Linux -->
-		<import addon="script.module.dropbox" version="2.2.2"/> <!-- For Dropbox synchronisation -->
+		<import addon="script.module.dropbox" version="8.4.0"/> <!-- For Dropbox synchronisation -->
 	</requires>
 	<extension point="xbmc.python.script" library="manual.py"> <!--Python code for manual start in the addons menu-->
 	  <provides>executable</provides> <!-- Addon is shown under Programs -->


### PR DESCRIPTION
Hello,

These are the calls to update the addon to the new dropbox API.

I've noticed something that might be a (minor) problem on first run (eg: first time setting up dropbox)... It looks like if there is a download error in pullFromDropbox we never attempt to upload. But if the file has never been uploaded we always get that error.

I'm also noticing that in certain situations (I've not tracked down why just yet) we delete the backup and the real file to trigger the situation above.

Anyway, this makes it compatible but I'm seeing some problems as I'm testing it.