### PR TITLE
Add an additional check for an existing MySQL connection

### DIFF
--- a/lib/watchedlist/watchedlist.py
+++ b/lib/watchedlist/watchedlist.py
@@ -321,9 +321,10 @@ class WatchedList:
                         return 1  # wait 3 minutes so the dialogue does not pop up directly after the playback ends
 
             # load the addon-database
-            if self.load_db(True):  # True: Manual start
-                utils.showNotification(utils.getString(32102), utils.getString(32601), xbmc.LOGERROR)
-                return 3
+            if self.sqlcursor_wl == 0 or self.sqlcon_wl == 0:
+                if self.load_db(True):  # True: Manual start
+                    utils.showNotification(utils.getString(32102), utils.getString(32601), xbmc.LOGERROR)
+                    return 3
 
             if self.sync_tvshows():
                 utils.showNotification(utils.getString(32102), utils.getString(32604), xbmc.LOGERROR)


### PR DESCRIPTION
I have had a problem in which the addon opens two simultaneous connections to my MariaDB server. This results in the addon hanging up indefinitely, apparently waiting for the results of a query which the `mysql` CLI reports is "Waiting for table metadata lock".

I have added a check for an existing db connection in `runUpdate()` (which contained the only `load_db()` call not already protected by such a check). This seems to have fixed the problem for me.