### PR TITLE
This commit is a fix for [bug #28](https://github.com/SchapplM/xbmc-a…

### DIFF
--- a/lib/watchedlist/utils.py
+++ b/lib/watchedlist/utils.py
@@ -132,20 +132,33 @@ def sqlDateTimeToTimeStamp(sqlDateTime):
         except BaseException:
             return 0  # error, but timestamp=0 works in the addon
 
-
-def TimeStamptosqlDateTime(TimeStamp):
-    """Convert Unix Timestamp to SQLite DateTime
+def TimeStamptostringDateTime(TimeStamp):
+    """Convert Unix Timestamp to DateTime or an empty string
 
         Args:
             timestamp: E.g. 1368213804
 
         Returns:
             sqlDateTime: E.g. "2013-05-10 21:23:24"
+            Empty string: E.g. ""
     """
     if TimeStamp == 0:
         return ""
     return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(TimeStamp))
 
+def TimeStamptosqlDateTime(TimeStamp):
+    """Convert Unix Timestamp to SQL DateTime or None
+
+        Args:
+            timestamp: E.g. 1368213804
+
+        Returns:
+            sqlDateTime: E.g. "2013-05-10 21:23:24"
+            None
+    """
+    if TimeStamp == 0:
+        return None
+    return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(TimeStamp))
 
 def executeJSON(request):
     """Execute JSON-RPC Command


### PR DESCRIPTION
Hello

This commit is a fix for [bug #28](https://github.com/SchapplM/xbmc-addon-service-watchedlist/issues/28)

* Changed the name of the utils method TimeStamptosqlDateTime to TimeStamptostringDateTime as SQL would not allow an empty string time and in the current usage it ends converted to '1970-01-01 00:00:00' when combined with a query using FROM_UNIXTIME. Also this function was not used in SQL context but in logging context.
* Changed all references to TimeStamptosqlDateTime with TimeStamptostringDateTime to reflect the point above.
* Removed the usage of FROM_UNIXTIME and replaced that with a utils method 
* Recycled the above method name TimeStamptosqlDateTime to create a new method returning a valid datetime or the object None instead of emptyness to be used in SQL context as mysql.connector then converts that to NULL when executed.
* Filtered all the old execute values that used to use FROM_UNIXTIME to now go trough TimeStamptosqlDateTime instead to correct errors at the add-on level instead of in the query.
