### PR TITLE
Fix Episode Handling for 'Local Information Only' Setup in Kodi 21

### DIFF
--- a/lib/watchedlist/watchedlist.py
+++ b/lib/watchedlist/watchedlist.py
@@ -654,12 +654,10 @@ class WatchedList:
                     for item in json_response['result'][searchkey]:
                         if self.monitor.abortRequested():
                             break
-                        if not 'uniqueid' in item:
-                            if modus == 'movie':
+                        if modus == 'movie':
+                            if not 'uniqueid' in item:
                                 utils.log(u'get_watched_xbmc: Movie %s has no field uniqueid in database. Try rescraping.' % (item['title']), xbmc.LOGINFO)
-                            else:  # episode
-                                utils.log(u'get_watched_xbmc: Episode id %d (show %d, S%02dE%02d) has no field uniqueid in database. Try rescraping.' % (item['episodeid'], item['tvshowid'], item['season'], item['episode']), xbmc.LOGINFO)
-                            continue
+                                continue
                         if modus == 'movie':
                             name = item['title'] + ' (' + str(item['year']) + ')'
                             try:


### PR DESCRIPTION
When the database is built with "local information only," there are no IDs for episodes. These are not needed here either, as the IDs from the series are used. Therefore, at this point, only the check for movies is needed.

Background:
I'm switching from Kodi 18 to 21. I have my entire media library using only local information ("nfo" files), which I generate with TinyMediaManager.
The episode query:
```
json_response = utils.executeJSON({
                        "jsonrpc": "2.0",
                        "method": "VideoLibrary.GetEpisodes",
                        "params": {
                            "properties": ["tvshowid", "season", "episode", "playcount", "showtitle", "lastplayed", "uniqueid"]
                        },
                        "id": 1
                    })
```
Returns in Kodi 18:
```
{
                "episode": 12,
                "episodeid": 4269,
                "label": "5x12. Rückfall",
                "lastplayed": "2024-12-10 22:15:52",
                "playcount": 1,
                "season": 5,
                "showtitle": "FBI",
                "tvshowid": 53,
                "uniqueid": {
                    "unknown": ""
                }
            },
```
Returns in Kodi 21:
```
{
                "episode": 12,
                "episodeid": 2795,
                "label": "5x12. Rückfall",
                "lastplayed": "",
                "playcount": 0,
                "season": 5,
                "showtitle": "FBI",
                "tvshowid": 135
            },
```
The unknown uniquid is ignored in the section of the code. But now their are none uniqueid and the episode is ignored.
With this change, WatchedList works perfectly again.